### PR TITLE
update regexes to support short-form urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The action looks for Trello card URLs at the start of a Pull Request description
 Optionally, this can be configured to also attach (redundant) PR comments with card links/names, similar to what the Trello Power-up will do, for use cases requiring that.
 
 ## Link-Finding
-URLs need to each be on own line (leading/trailing whitespace and extra blank lines don't matter), and be at top of PR body.  URLs embedded in other text are ignored, as are URLs after descriptive (i.e., non-link) text starts.
+URLs need to each be on own line (leading/trailing whitespace and extra blank lines don't matter), and be at top of PR body.  URLs embedded in other text are ignored, as are URLs after descriptive (i.e., non-link) text starts.  Both the short-form (from the "Link to this card" field provided by a card's "Share" button) or long-form (cmd/ctrl+c with card open, copy from url bar with card open, etc.) are supported.
 
 So, for :
 ```text
 https://trello.com/c/aaaaaaaa
 
-https://trello.com/c/bbbbbbbbb
+https://trello.com/c/bbbbbbbbb/111-qqqqqqqqqqqq
 This PR impl's the above 2 features.  These work similarly to feature https://trello.com/c/ccccccccc.  
 The below is a random trello url put in this body, for some reason:
 https://trello.com/c/dddddddd

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ const extractTrelloCardIds = (prBody, stopOnNonLink = true) =>   {
   // browsers submit textareas with \r\n line breaks on all platforms
   const browserEol = '\r\n';
   // requires that link be alone own line, and allows leading/trailing whitespace
-  const linkRegex = /^\s*(https\:\/\/trello\.com\/c\/(\w+)\/\S+)?\s*$/;
+  const linkRegex = /^\s*(https\:\/\/trello\.com\/c\/(\w+)(\/\S*)?)?\s*$/;
   
   const cardIds = [];
   const lines = prBody.split(browserEol);
@@ -110,7 +110,7 @@ const extractTrelloCardIds = (prBody, stopOnNonLink = true) =>   {
 }
 
 const commentsContainsTrelloLink = async (cardId) => {
-  const linkRegex = new RegExp(`\\[[^\\]]+\\]\\(https:\\/\\/trello.com\\/c\\/${cardId}\\/[^)]+\\)`);
+  const linkRegex = new RegExp(`\\[[^\\]]+\\]\\(https:\\/\\/trello.com\\/c\\/${cardId}(\\/[^)]*)?\\)`);
 
   const comments = await getPrComments();  
   return comments.data.some((comment) => linkRegex.test(comment.body));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attach-to-trello-card-action",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Github Action: Add attachment to a given Trello card URL (e.g., pull request)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Update link-finding regexes to support both `https://trello.com/c/bbbbbbbbb` and `https://trello.com/c/bbbbbbbbb/111-qqqqqqqqqqqq` formats (issue #12)

